### PR TITLE
[BE] Refactor : 유저 정보 조회 방식 통일 완료

### DIFF
--- a/BE/src/main/java/com/softeer/team6four/domain/carbob/application/CarbobRegistrationService.java
+++ b/BE/src/main/java/com/softeer/team6four/domain/carbob/application/CarbobRegistrationService.java
@@ -24,10 +24,8 @@ import com.softeer.team6four.domain.reservation.application.ReservationMapper;
 import com.softeer.team6four.domain.reservation.domain.Reservation;
 import com.softeer.team6four.domain.reservation.domain.ReservationLine;
 import com.softeer.team6four.domain.reservation.domain.ReservationRepository;
-import com.softeer.team6four.domain.user.application.exception.UserException;
+import com.softeer.team6four.domain.user.application.UserSearchService;
 import com.softeer.team6four.domain.user.domain.User;
-import com.softeer.team6four.domain.user.domain.UserRepository;
-import com.softeer.team6four.global.response.ErrorCode;
 import com.softeer.team6four.global.response.ResponseDto;
 
 import lombok.RequiredArgsConstructor;
@@ -37,15 +35,14 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 public class CarbobRegistrationService {
-	private final UserRepository userRepository;
 	private final CarbobRepository carbobRepository;
 	private final ReservationRepository reservationRepository;
 	private final ApplicationEventPublisher eventPublisher;
+	private final UserSearchService userSearchService;
 
 	@Transactional
 	public ResponseDto<Void> registerCarbob(Long userId, CarbobRegistration carbobRegistration) {
-		User host = userRepository.findById(userId)
-			.orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+		User host = userSearchService.findUserByUserId(userId);
 
 		CarbobLocation location = CarbobLocation.builder()
 			.address(carbobRegistration.getAddress())

--- a/BE/src/main/java/com/softeer/team6four/domain/reservation/ReservationConverterService.java
+++ b/BE/src/main/java/com/softeer/team6four/domain/reservation/ReservationConverterService.java
@@ -14,9 +14,8 @@ import com.softeer.team6four.domain.reservation.domain.Reservation;
 import com.softeer.team6four.domain.reservation.domain.ReservationRepository;
 import com.softeer.team6four.domain.reservation.domain.StateType;
 import com.softeer.team6four.domain.reservation.infra.ReservationCheckEvent;
-import com.softeer.team6four.domain.user.application.exception.UserException;
+import com.softeer.team6four.domain.user.application.UserSearchService;
 import com.softeer.team6four.domain.user.domain.User;
-import com.softeer.team6four.domain.user.domain.UserRepository;
 import com.softeer.team6four.global.response.ErrorCode;
 import com.softeer.team6four.global.response.ResponseDto;
 
@@ -29,7 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ReservationConverterService {
 	private final ApplicationEventPublisher eventPublisher;
 	private final ReservationRepository reservationRepository;
-	private final UserRepository userRepository;
+	private final UserSearchService userSearchService;
 
 	@Transactional
 	public ResponseDto<ReservationCheckInfo> converterReservationState
@@ -43,8 +42,7 @@ public class ReservationConverterService {
 
 		reservation.updateStateType(reservationCheck.getStateType());
 
-		User host = userRepository.findById(hostUserId)
-			.orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+		User host = userSearchService.findUserByUserId(hostUserId);
 		User guest = reservation.getGuest();
 		Carbob carbob = reservation.getCarbob();
 

--- a/BE/src/main/java/com/softeer/team6four/domain/reservation/application/ReservationCreateService.java
+++ b/BE/src/main/java/com/softeer/team6four/domain/reservation/application/ReservationCreateService.java
@@ -17,9 +17,8 @@ import com.softeer.team6four.domain.reservation.domain.ReservationLine;
 import com.softeer.team6four.domain.reservation.domain.ReservationRepository;
 import com.softeer.team6four.domain.reservation.infra.ReservationCreatedEvent;
 import com.softeer.team6four.domain.reservation.infra.ReservationRepositoryImpl;
-import com.softeer.team6four.domain.user.application.exception.UserException;
+import com.softeer.team6four.domain.user.application.UserSearchService;
 import com.softeer.team6four.domain.user.domain.User;
-import com.softeer.team6four.domain.user.domain.UserRepository;
 import com.softeer.team6four.global.annotation.DistributedLock;
 import com.softeer.team6four.global.response.ErrorCode;
 
@@ -32,10 +31,10 @@ import lombok.extern.slf4j.Slf4j;
 public class ReservationCreateService {
 	private final ApplicationEventPublisher eventPublisher;
 
-	private final UserRepository userRepository;
 	private final CarbobRepository carbobRepository;
 	private final ReservationRepository reservationRepository;
 	private final ReservationRepositoryImpl reservationRepositoryImpl;
+	private final UserSearchService userSearchService;
 
 	@DistributedLock(key = "'carbobReservation:' + #reservationApply.getCarbobId() + ':' + #reservationApply.getApplyDate() ")
 	public Long makeReservationToCarbobV1(Long userId, ReservationApply reservationApply) {
@@ -43,8 +42,7 @@ public class ReservationCreateService {
 			throw new InvalidReservationTimeLinesException(ErrorCode.INVALID_RESERVATION_TIME_LINES);
 		}
 
-		User user = userRepository.findById(userId)
-			.orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+		User user = userSearchService.findUserByUserId(userId);
 
 		Carbob carbob = carbobRepository.findById(reservationApply.getCarbobId())
 			.orElseThrow(() -> new CarbobNotFoundException(ErrorCode.CARBOB_NOT_FOUND));


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- [x] #76

## 📝 작업 내용

User 정보 조회를 할 때 어느 곳에서는 UserSearchService를 통해 진행하고, 다른 곳에서는 userRepository.findById()를 사용하여 조회하고 있어서 UserSearchService를 사용하는 방식으로 통일

### 스크린샷 (선택)

<img width="799" alt="스크린샷 2024-02-19 오후 3 25 07" src="https://github.com/softeerbootcamp-3rd/Team6-6Four/assets/101091999/55d5a2a9-9dfb-44ad-ae40-020c62463ddf">

## 💬 리뷰 요구사항(선택)